### PR TITLE
fix: add rounded corner to preview tab hover

### DIFF
--- a/components/mdx-components.jsx
+++ b/components/mdx-components.jsx
@@ -208,6 +208,9 @@ const StyledTab = styled(Tab)(({ theme }) => ({
         ? "rgba(255,255,255,0.05)"
         : "rgba(0,0,0,0.05)",
   },
+  "&:first-of-type:hover": {
+    borderTopLeftRadius: theme.shape.borderRadius * 2, 
+  },
 }));
 
 const CodePreview = ({


### PR DESCRIPTION
## Summary

Adds a rounded top-left corner to the Preview tab hover state to better match the border radius of the surrounding container.

## Changes

- Add top-left border radius to the Preview tab on hover.

## Screenshots

### Before
https://github.com/user-attachments/assets/0759787f-92e5-4852-9d62-1d6d8cdd8e30

### After
https://github.com/user-attachments/assets/0a53eaec-9192-4d5c-95ca-10803bf1bbdc
